### PR TITLE
Fix compilation with cabal in try-reflex shell

### DIFF
--- a/reflex-dom-datepicker.cabal
+++ b/reflex-dom-datepicker.cabal
@@ -32,6 +32,7 @@ library
                      , text >= 1.2 && < 1.3
                      , reflex >= 0.5 && < 0.7
                      , reflex-dom-core >= 0.4 && < 0.6
+                     , ghcjs-dom
                      , lens > 4 && < 5
                      , containers >= 0.5 && < 0.7
                      , time >= 1.6


### PR DESCRIPTION
It seems that `ghcjs-dom` is required to compile with current reflex-platform. If it is not in the dependencies, here is the output of cabal new-build: 

```
cabal new-build
Resolving dependencies...
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - reflex-dom-datepicker-0.1.0 (lib) (configuration changed)
Configuring library for reflex-dom-datepicker-0.1.0..
Preprocessing library for reflex-dom-datepicker-0.1.0..
Building library for reflex-dom-datepicker-0.1.0..
[2 of 8] Compiling Reflex.Dom.Widget.Input.Datepicker.Types ( src/Reflex/Dom/Widget/Input/Datepicker/Types.hs, /home/jc/Documents/Dev/haskell/reflex-dom-datepicker/dist-newstyle/build/x86_64-linux/ghc-8.6.5/reflex-dom-datepicker-0.1.0/build/Reflex/Dom/Widget/Input/Datepicker/Types.o ) [GHCJS.DOM.HTMLInputElement changed]

src/Reflex/Dom/Widget/Input/Datepicker/Types.hs:24:1: error:
    Could not load module `GHCJS.DOM.HTMLInputElement'
    It is a member of the hidden package `jsaddle-dom-0.9.2.0'.
    Perhaps you need to add `jsaddle-dom' to the build-depends in your .cabal file.
    Use -v to see a list of the files searched for.
   |
24 | import           GHCJS.DOM.HTMLInputElement (HTMLInputElement)
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

